### PR TITLE
Fix checking `wait_loading_present` for non-mobile users

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -13,7 +13,7 @@ Metrics/AbcSize:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 142
+  Max: 143
 
 # Offense count: 2
 Metrics/CyclomaticComplexity:

--- a/Changelog.md
+++ b/Changelog.md
@@ -7,3 +7,5 @@
 * Ability to get `DocTestSiteFileListEntry#fill_forms_mode_url`
 
 ### Fixes
+
+* Fix checking `wait_loading_present` for non-mobile users

--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs/management.rb
@@ -16,6 +16,7 @@ module OnlyofficeDocumentserverTestingFramework
       raise "Service Unavailable. There is alert while loading docs: \"#{@instance.webdriver.alert_text}\"" if @instance.webdriver.alert_exists?
 
       @instance.selenium.select_frame(@xpath_iframe, @xpath_iframe_count)
+      mobile_loader = false
       loader1 = @instance.selenium.element_visible?('//div[contains(@id,"cmdloadmask")]')
       loader2 = @instance.selenium.element_visible?('//*[contains(@class,"loadmask")]')
       loader3 = @instance.selenium.element_visible?('//*[@class="asc-loadmask-body "]')
@@ -24,9 +25,9 @@ module OnlyofficeDocumentserverTestingFramework
       loader6 = @instance.selenium.element_visible?('//*[@class="modals-mask"]')
       loader7 = @instance.selenium.element_visible?('//*[@class="asc-loadmask"]')
       loader8 = @instance.selenium.element_visible?(@xpath_window_modal)
-      loader9 = wait_for_mobile_loading if main_frame_mobile_element_visible?
+      mobile_loader = wait_for_mobile_loading if main_frame_mobile_element_visible?
       @instance.selenium.select_top_frame
-      loading = loader1 || loader2 || loader3 || loader4 || loader5 || loader6 || loader7 || loader8 || loader9
+      loading = loader1 || loader2 || loader3 || loader4 || loader5 || loader6 || loader7 || loader8 || mobile_loader
       OnlyofficeLoggerHelper.log("Loading Present: #{loading}")
       loading
     end


### PR DESCRIPTION
loader9 can be unitialize so loading status return nil
and broke API tests on production since it used this method