### PR TITLE
Fix issue with using old webdriver while running several tests

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/test_instance_docs.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/test_instance_docs.rb
@@ -20,7 +20,9 @@ module OnlyofficeDocumentserverTestingFramework
     end
 
     def doc_test_functions
-      @doc_test_functions ||= DocTestSiteFunctions.new(self)
+      # Do not cache methods since they use PageObject and cause all sort of troubles
+      # if test run several times with different webdriver
+      DocTestSiteFunctions.new(self)
     end
 
     def doc_editor


### PR DESCRIPTION
See error in palladium:
/product/4/plan/687/run/49902/result_set/1631395