### PR TITLE
Simplify check of frame variables is defined

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper.rb
@@ -37,8 +37,8 @@ module OnlyofficeDocumentserverTestingFramework
     end
 
     def select_frame
-      count_of_frame = instance_variable_defined?(:@count_of_frame) ? @count_of_frame + @instance.management.xpath_iframe_count - 1 : @instance.management.xpath_iframe_count
-      xpath_of_frame = instance_variable_defined?(:@xpath_of_frame) ? @xpath_of_frame : @instance.management.xpath_iframe
+      count_of_frame = @count_of_frame ? (@count_of_frame + @instance.management.xpath_iframe_count - 1) : @instance.management.xpath_iframe_count
+      xpath_of_frame = @xpath_of_frame || @instance.management.xpath_iframe
       @instance.selenium.select_frame xpath_of_frame, count_of_frame
       value = yield
       fail_if_console_error


### PR DESCRIPTION
Allow to set variables to nil, but keep this work