### PR TITLE
Change method to require file in Gem

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors.rb
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors.rb
@@ -6,7 +6,7 @@ module SeleniumWrapperJsErrors
   def ignored_errors
     return @ignored_errors if @ignored_errors
 
-    @ignored_errors = File.readlines("#{Dir.pwd}/lib/onlyoffice_documentserver_testing_framework"\
+    @ignored_errors = File.readlines("#{File.expand_path('..', __dir__)}"\
                                      '/selenium_wrapper/selenium_wrapper_js_errors'\
                                      '/ingored_errors.list')
                           .map(&:strip)


### PR DESCRIPTION
Previous variant cause that root directory
counted as project root dir in wihch gem required.