### PR TITLE
Remove gem update system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ matrix:
   - rvm: ruby-head
 
 before_install:
-  - gem update --system
   - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome.deb
   - rm google-chrome.deb

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,10 +8,6 @@ rvm:
   - 2.6
   - 2.5
 
-matrix:
-  allow_failures:
-  - rvm: ruby-head
-
 before_install:
   - curl -L -o google-chrome.deb https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   - sudo dpkg -i google-chrome.deb


### PR DESCRIPTION
This cause dialog for override gem in `ruby-head`
like this and hangup for 10 minutes:
```
$ gem update --system
Updating rubygems-update
Fetching rubygems-update-3.1.0.pre2.gem
Successfully installed rubygems-update-3.1.0.pre2
Installing RubyGems 3.1.0.pre2
  Successfully built RubyGem
  Name: bundler
  Version: 2.1.0.pre.2
  File: bundler-2.1.0.pre.2.gem
bundler's executable "bundle" conflicts with /home/travis/.rvm/rubies/ruby-head/bin/bundle
Overwrite the executable? [yN]
No output has been received in the last 10m0s, this potentially indicates a stalled build or something wrong with the build itself.
```