### PR TITLE
Change autofocus error for youtube plugin

### DIFF
--- a/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
+++ b/lib/onlyoffice_documentserver_testing_framework/selenium_wrapper/selenium_wrapper_js_errors/ignored_errors.list
@@ -22,5 +22,5 @@ SockJS has already been closed
 Failed to load resource: the server responded with a status of 404 ()
 AscFonts
 yastatic.net/maps-beta
-sdkjs-plugins/youtube/index.html?lang=en-US - Blocked autofocusing on a form control in a cross-origin subframe.
+Blocked autofocusing on a form control in a cross-origin subframe.
 /embed


### PR DESCRIPTION
Seems there is line number after `en-US` string
in current version of chrome
See:
https://bugzilla.onlyoffice.com/show_bug.cgi?id=43989