### PR TITLE
Allow CI failures on ruby-head

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -3,9 +3,14 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.allow-failures }}
     strategy:
       matrix:
-        ruby: [2.5, 2.6, 2.7, head]
+        ruby: [2.5, 2.6, 2.7]
+        allow-failures: [false]
+        include:
+          - ruby: head
+            allow-failures: true    
     steps:
     - name: Update to current stable google-chrome
       run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 ### Changes
 
 * Add one more ignored error for YouTube plugin autofocus
+* Allow CI failures on `ruby-head`
 
 ## 0.1.1 (2020-08-11)
 


### PR DESCRIPTION
From [yesterday](https://github.com/ruby/ruby/commit/21c62fb670b1646c5051a46d29081523cd782f11) ruby 2.8 is ruby 3.0 and some gems just can't be installed on it

Until at least https://github.com/simplecov-ruby/simplecov-html/commit/6567856c6940e285bbb70cce98edca60c7dfefdd2 is released